### PR TITLE
Fixing directory name specified in emotional design hunt

### DIFF
--- a/week-13/emotional-design-hunt.txt
+++ b/week-13/emotional-design-hunt.txt
@@ -8,7 +8,7 @@ Then, locate a physical object that you use regularly in your life (does not hav
 
 ## Deliverables
 
-A. Photograph of the object (place in the week-12/ directory and commit).
+A. Photograph of the object (place in the week-13/ directory and commit).
 
 B. Emotional design levels of your object:
 


### PR DESCRIPTION
It specified to place a photograph in the `week-12` directory while the problem is in the `week-13` directory. This tiny change fixes that.
